### PR TITLE
Set authorize_url to api.youneedabudget.com

### DIFF
--- a/src/ynabRepo.js
+++ b/src/ynabRepo.js
@@ -14,7 +14,7 @@ const BUDGETS_STORAGE_KEY = "ynab_budgets";
 const TIME_LIMIT_FOR_FULL_REFRESH = 8 * 1000;
 
 export const AUTHORIZE_URL =
-  "https://app.youneedabudget.com/oauth/authorize?client_id=" +
+  "https://api.youneedabudget.com/oauth/authorize?client_id=" +
   clientId +
   "&redirect_uri=" +
   redirectUri +


### PR DESCRIPTION
The app. endpoint interferes with mobile apps (clicking the link on Android opens the YNAB App which can't handle oauth authentication).

This will be fixed on YNAB's side as well, but the documentation points to api. so it's more correct anyway.