### PR TITLE
Fix Mortgage Accounts Not Showing In Settings

### DIFF
--- a/src/components/SettingsMortgageAccounts.js
+++ b/src/components/SettingsMortgageAccounts.js
@@ -26,7 +26,7 @@ const SettingsMortgageAccounts = ({
   ] = useFlagState(false);
 
   const potentialMortageAccounts = budget.accounts.filter(
-    account => (account.type === "otherLiability" || "mortgage") && !account.on_budget
+    account => account.type.match(/^(otherLiability|mortgage)$/) && !account.on_budget
   );
   const mortgageAccountList = budget.accounts.filter(
     ({ id }) => mortgageAccounts[id]

--- a/src/components/SettingsMortgageAccounts.js
+++ b/src/components/SettingsMortgageAccounts.js
@@ -26,7 +26,7 @@ const SettingsMortgageAccounts = ({
   ] = useFlagState(false);
 
   const potentialMortageAccounts = budget.accounts.filter(
-    account => account.type === "otherLiability" && !account.on_budget
+    account => (account.type === "otherLiability" || "mortgage") && !account.on_budget
   );
   const mortgageAccountList = budget.accounts.filter(
     ({ id }) => mortgageAccounts[id]


### PR DESCRIPTION
The current YNAB version allows users to have a mortgage account with a type of "mortgage" in addition to "otherLiability".

I also switched to using a regex to make adding new types easier in the future.

 Please see the BudgetSummaryResponse Model in the [YNAB API](https://api.youneedabudget.com/v1) for info on budget types.